### PR TITLE
fix: Update target link lib to support color space convert feature

### DIFF
--- a/qrb_colorspace_convert_lib/CMakeLists.txt
+++ b/qrb_colorspace_convert_lib/CMakeLists.txt
@@ -27,8 +27,8 @@ else()
   )
 
   target_link_libraries(${PROJECT_NAME}
-    EGL
-    GLESv2
+    ${CMAKE_SYSROOT}/usr/lib/libEGL_adreno.so.1
+    ${CMAKE_SYSROOT}/usr/lib/libGLESv2_adreno.so.2
   )
 endif()
 


### PR DESCRIPTION
CRs-Fixed: 4448179

**Motivation**
- Update target link lib to support color space convert feature
- On QLI 1.0, the platform provided link mapping between libGLESv2.so.2 and libGLESv2_adreno.so.2
- While in QLI 0.0, the link relationship was removed. The default GLES lib link to the libglvnd
- Need to link the qcom-adreno directly

**Impact**
Meet symbol miss like glEGLImageTargetTexture2DOES on runtime.
